### PR TITLE
Added ability to manual specify connection rather than use discovery.

### DIFF
--- a/custom_components/airtouch/__init__.py
+++ b/custom_components/airtouch/__init__.py
@@ -8,11 +8,13 @@ import logging
 from typing import TYPE_CHECKING
 
 import pyairtouch
-from homeassistant.const import CONF_HOST, Platform
+from homeassistant.const import CONF_HOST, CONF_PORT, Platform
 from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import (
+    CONF_MANUAL_CONNECTION,
     CONF_MINOR_VERSION,
+    CONF_MODEL,
     CONF_VERSION,
     DOMAIN,
 )
@@ -37,7 +39,7 @@ PLATFORMS: list[Platform] = [
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up the Polyaire AirTouch connection after discovery."""
+    """Set up the Polyaire AirTouch connection."""
     _LOGGER.debug(
         "ConfigEntry (v%d.%d): %s",
         entry.version,
@@ -49,18 +51,34 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # A lock is included to support mutual exclusion between config entries.
     hass.data.setdefault(DOMAIN, {_LOCK_KEY: asyncio.Lock()})
 
-    # Ensure discovery is mutually exlusive across config entries since it needs
-    # to bind to an explicit local port.
-    async with hass.data[DOMAIN][_LOCK_KEY]:
-        discovery_results = await pyairtouch.discover(
-            remote_host=entry.data.get(CONF_HOST)
+    airtouch: pyairtouch.AirTouch | None = None
+
+    if entry.data.get(CONF_MANUAL_CONNECTION):
+        # Manual connection mode - use pyairtouch.connect() directly
+        model = getattr(pyairtouch.AirTouchModel, entry.data[CONF_MODEL])
+        host = entry.data[CONF_HOST]
+        port = entry.data[CONF_PORT]
+
+        airtouch = pyairtouch.connect(
+            model=model,
+            host=host,
+            port=port,
+        )
+    else:
+        # Discovery mode - use pyairtouch.discover()
+        # Ensure discovery is mutually exclusive across config entries since it needs
+        # to bind to an explicit local port.
+        async with hass.data[DOMAIN][_LOCK_KEY]:
+            discovery_results = await pyairtouch.discover(
+                remote_host=entry.data.get(CONF_HOST)
+            )
+
+        # Filter the API instances to the AirTouch controller that matches this
+        # config entry.
+        airtouch = next(
+            (at for at in discovery_results if entry.unique_id == at.airtouch_id), None
         )
 
-    # Filter the API instances to the AirTouch controller that matches this
-    # config entry.
-    airtouch = next(
-        (at for at in discovery_results if entry.unique_id == at.airtouch_id), None
-    )
     if not airtouch:
         # Couldn't find the AirTouch device.
         # As a general rule this shouldn't happen because we are using discovery.

--- a/custom_components/airtouch/config_flow.py
+++ b/custom_components/airtouch/config_flow.py
@@ -7,6 +7,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import (
     CONF_HOST,
+    CONF_PORT,
     PRECISION_HALVES,
     PRECISION_TENTHS,
     PRECISION_WHOLE,
@@ -15,7 +16,11 @@ from homeassistant.core import callback
 from homeassistant.helpers import selector
 
 from .const import (
+    AT4_DEFAULT_PORT,
+    AT5_DEFAULT_PORT,
+    CONF_MANUAL_CONNECTION,
     CONF_MINOR_VERSION,
+    CONF_MODEL,
     CONF_SPILL_BYPASS,
     CONF_SPILL_ZONES,
     CONF_VERSION,
@@ -49,10 +54,116 @@ class AirTouchConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     # Compatibility: Before 2024.4:
     # Return type is quoted for type checking only since it is new in 2024.4.
     async def async_step_user(
-        self, _: dict[str, Any] | None = None
+        self, user_input: dict[str, Any] | None = None
     ) -> "config_entries.ConfigFlowResult":
-        """Handle a flow initialised by the user."""
-        return await self.async_step_discover_airtouch()
+        """Handle a flow initialised by the user.
+
+        Presents a choice between auto-discovery and manual configuration.
+        """
+        if user_input is not None:
+            if user_input.get("connection_method") == "manual":
+                return await self.async_step_manual_config()
+            return await self.async_step_discover_airtouch()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        "connection_method", default="discover"
+                    ): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=[
+                                selector.SelectOptionDict(
+                                    value="discover", label="Auto-discover"
+                                ),
+                                selector.SelectOptionDict(
+                                    value="manual", label="Manual configuration"
+                                ),
+                            ],
+                            mode=selector.SelectSelectorMode.LIST,
+                            translation_key="connection_method",
+                        )
+                    ),
+                }
+            ),
+        )
+
+    async def async_step_manual_config(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> "config_entries.ConfigFlowResult":
+        """Handle manual configuration of AirTouch connection details."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            model_name = user_input[CONF_MODEL]
+            host = user_input[CONF_HOST]
+            port = user_input[CONF_PORT]
+
+            # Convert model name to enum (using getattr since we store enum member names)
+            model = getattr(pyairtouch.AirTouchModel, model_name)
+
+            # Try to connect to validate the configuration
+            try:
+                airtouch = pyairtouch.connect(
+                    model=model,
+                    host=host,
+                    port=port,
+                )
+                # Initialize to validate connection and get device info
+                if await airtouch.init():
+                    # Store connection details in context
+                    self.context[CONF_HOST] = host  # type: ignore[literal-required]
+                    self.context[CONF_PORT] = port  # type: ignore[literal-required]
+                    self.context[CONF_MODEL] = model_name  # type: ignore[literal-required]
+                    self.context[CONF_MANUAL_CONNECTION] = True  # type: ignore[literal-required]
+                    self.context[_CONTEXT_TITLE] = airtouch.name  # type: ignore[literal-required]
+                    self.context[_CONTEXT_AIRTOUCH_API] = airtouch  # type: ignore[literal-required]
+                    self.context[_CONTEXT_REMAINING_AIRTOUCHES] = []  # type: ignore[literal-required]
+
+                    # Set unique ID based on host and port for manual connections
+                    await self.async_set_unique_id(f"{host}:{port}")
+                    self._abort_if_unique_id_configured()
+
+                    return await self.async_step_settings()
+                else:
+                    await airtouch.shutdown()
+                    errors["base"] = "cannot_connect"
+            except Exception:  # noqa: BLE001
+                errors["base"] = "cannot_connect"
+
+        # Determine default port based on model selection
+        default_port = AT4_DEFAULT_PORT
+
+        return self.async_show_form(
+            step_id="manual_config",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_MODEL, default="AIRTOUCH_4"
+                    ): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=[
+                                selector.SelectOptionDict(
+                                    value="AIRTOUCH_4", label="AirTouch 4"
+                                ),
+                                selector.SelectOptionDict(
+                                    value="AIRTOUCH_5", label="AirTouch 5"
+                                ),
+                            ],
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                            translation_key="model",
+                        )
+                    ),
+                    vol.Required(CONF_HOST): str,
+                    vol.Required(CONF_PORT, default=default_port): vol.All(
+                        vol.Coerce(int), vol.Range(min=1, max=65535)
+                    ),
+                }
+            ),
+            errors=errors,
+        )
 
     async def async_step_discover_airtouch(
         self,
@@ -215,13 +326,22 @@ class AirTouchConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 step_id="finalise",
             )
 
+        # Build the data dictionary
+        entry_data: dict[str, Any] = {
+            CONF_HOST: self.context[CONF_HOST],  # type: ignore[literal-required]
+            CONF_SPILL_BYPASS: self.context[CONF_SPILL_BYPASS],  # type: ignore[literal-required]
+            CONF_SPILL_ZONES: self.context[CONF_SPILL_ZONES],  # type: ignore[literal-required]
+        }
+
+        # Add manual connection data if applicable
+        if self.context.get(CONF_MANUAL_CONNECTION):  # type: ignore[literal-required]
+            entry_data[CONF_MANUAL_CONNECTION] = True
+            entry_data[CONF_MODEL] = self.context[CONF_MODEL]  # type: ignore[literal-required]
+            entry_data[CONF_PORT] = self.context[CONF_PORT]  # type: ignore[literal-required]
+
         return self.async_create_entry(
             title=self.context[_CONTEXT_TITLE],  # type: ignore[literal-required]
-            data={
-                CONF_HOST: self.context[CONF_HOST],  # type: ignore[literal-required]
-                CONF_SPILL_BYPASS: self.context[CONF_SPILL_BYPASS],  # type: ignore[literal-required]
-                CONF_SPILL_ZONES: self.context[CONF_SPILL_ZONES],  # type: ignore[literal-required]
-            },
+            data=entry_data,
             options={
                 OPTIONS_ALLOW_ZONE_HVAC_MODE_CHANGES: self.context[
                     OPTIONS_ALLOW_ZONE_HVAC_MODE_CHANGES  # type: ignore[literal-required]

--- a/custom_components/airtouch/const.py
+++ b/custom_components/airtouch/const.py
@@ -9,7 +9,16 @@ DOMAIN = "airtouch"
 MANUFACTURER = "Polyaire"
 
 CONF_VERSION = 2
-CONF_MINOR_VERSION = 1
+CONF_MINOR_VERSION = 2
+
+# Manual connection configuration
+CONF_MODEL = "model"
+CONF_PORT = "port"
+CONF_MANUAL_CONNECTION = "manual_connection"
+
+# Default ports for AirTouch models
+AT4_DEFAULT_PORT = 9004
+AT5_DEFAULT_PORT = 9005
 
 # Indicates whether the AirTouch is set up with a spill zone or with a bypass duct.
 CONF_SPILL_BYPASS = "spill_bypass"

--- a/custom_components/airtouch/strings.json
+++ b/custom_components/airtouch/strings.json
@@ -1,6 +1,27 @@
 {
   "config": {
     "step": {
+      "user": {
+        "title": "Connection Method",
+        "description": "Choose how to connect to your AirTouch system.",
+        "data": {
+          "connection_method": "Connection Method"
+        }
+      },
+      "manual_config": {
+        "title": "Manual Configuration",
+        "description": "Enter the connection details for your AirTouch system. Use this if auto-discovery is not working (e.g., Docker bridge network).",
+        "data": {
+          "model": "AirTouch Model",
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]"
+        },
+        "data_description": {
+          "model": "Select your AirTouch model.",
+          "host": "IP address or hostname of your AirTouch console.",
+          "port": "Port number (default: 9004 for AirTouch 4, 9005 for AirTouch 5)."
+        }
+      },
       "user_host": {
         "title": "Set up the AirTouch connection details",
         "description": "Enter the host name or IP Address of the AirTouch wall panel.",
@@ -34,7 +55,8 @@
     },
     "error": {
       "already_configured": "Already configured. Enter a new host name or IP address.",
-      "no_devices_found": "Couldn't connect to AirTouch console. Check the address and try again."
+      "no_devices_found": "Couldn't connect to AirTouch console. Check the address and try again.",
+      "cannot_connect": "Failed to connect to AirTouch. Please check the model, host, and port."
     }
   },
   "options": {
@@ -48,6 +70,18 @@
     }
   },
   "selector": {
+    "connection_method": {
+      "options": {
+        "discover": "Auto-discover",
+        "manual": "Manual configuration"
+      }
+    },
+    "model": {
+      "options": {
+        "airtouch_4": "AirTouch 4",
+        "airtouch_5": "AirTouch 5"
+      }
+    },
     "hvac_mode": {
       "options": {
         "cool": "Cool",

--- a/custom_components/airtouch/translations/en.json
+++ b/custom_components/airtouch/translations/en.json
@@ -2,9 +2,31 @@
   "config": {
     "error": {
       "already_configured": "Already configured. Enter a new host name or IP address.",
-      "no_devices_found": "Failed to connect to AirTouch console. Check the address and try again."
+      "no_devices_found": "Failed to connect to AirTouch console. Check the address and try again.",
+      "cannot_connect": "Failed to connect to AirTouch. Please check the model, host, and port."
     },
     "step": {
+      "user": {
+        "title": "Connection Method",
+        "description": "Choose how to connect to your AirTouch system.",
+        "data": {
+          "connection_method": "Connection Method"
+        }
+      },
+      "manual_config": {
+        "title": "Manual Configuration",
+        "description": "Enter the connection details for your AirTouch system. Use this if auto-discovery is not working (e.g., Docker bridge network).",
+        "data": {
+          "model": "AirTouch Model",
+          "host": "Host",
+          "port": "Port"
+        },
+        "data_description": {
+          "model": "Select your AirTouch model.",
+          "host": "IP address or hostname of your AirTouch console.",
+          "port": "Port number (default: 9004 for AirTouch 4, 9005 for AirTouch 5)."
+        }
+      },
       "finalise": {
         "description": "Run the \"Add Hub\" action from the integration settings page to register the others with Home Assistant.",
         "title": "More than one AirTouch systems were discovered"
@@ -48,6 +70,18 @@
     }
   },
   "selector": {
+    "connection_method": {
+      "options": {
+        "discover": "Auto-discover",
+        "manual": "Manual configuration"
+      }
+    },
+    "model": {
+      "options": {
+        "airtouch_4": "AirTouch 4",
+        "airtouch_5": "AirTouch 5"
+      }
+    },
     "hvac_mode": {
       "options": {
         "cool": "Cool",


### PR DESCRIPTION
I had some issues using the pyairtouch discovery service from my dockerized HA instance. 

I've AI generated this and tweaked it to suit my needs - manually applying it to my instance and it seems to work ok.

I thought I'd share the changes.