### PR TITLE
Add direct connection mode for consoles on a different subnet/VLAN

### DIFF
--- a/custom_components/airtouch/__init__.py
+++ b/custom_components/airtouch/__init__.py
@@ -12,9 +12,13 @@ from homeassistant.const import CONF_HOST, Platform
 from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import (
+    CONF_CONNECTION_MODE,
     CONF_MINOR_VERSION,
     CONF_VERSION,
+    DIRECT_PORT_AT4,
+    DIRECT_PORT_AT5,
     DOMAIN,
+    ConnectionMode,
 )
 
 if TYPE_CHECKING:
@@ -49,25 +53,49 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # A lock is included to support mutual exclusion between config entries.
     hass.data.setdefault(DOMAIN, {_LOCK_KEY: asyncio.Lock()})
 
-    # Ensure discovery is mutually exlusive across config entries since it needs
-    # to bind to an explicit local port.
-    async with hass.data[DOMAIN][_LOCK_KEY]:
-        discovery_results = await pyairtouch.discover(
-            remote_host=entry.data.get(CONF_HOST)
-        )
-
-    # Filter the API instances to the AirTouch controller that matches this
-    # config entry.
-    airtouch = next(
-        (at for at in discovery_results if entry.unique_id == at.airtouch_id), None
+    connection_mode = ConnectionMode(
+        entry.data.get(CONF_CONNECTION_MODE, ConnectionMode.DISCOVERY.value)
     )
-    if not airtouch:
-        # Couldn't find the AirTouch device.
-        # As a general rule this shouldn't happen because we are using discovery.
-        # However, it might happen if the AirTouch console is offline or the
-        # user configured with unicast discovery and the AirTouch console got a
-        # new IP address.
-        raise ConfigEntryNotReady("AirTouch not detected on network")
+
+    if connection_mode == ConnectionMode.DISCOVERY:
+        # Ensure discovery is mutually exlusive across config entries since it needs
+        # to bind to an explicit local port.
+        async with hass.data[DOMAIN][_LOCK_KEY]:
+            discovery_results = await pyairtouch.discover(
+                remote_host=entry.data.get(CONF_HOST)
+            )
+
+        # Filter the API instances to the AirTouch controller that matches this
+        # config entry.
+        airtouch = next(
+            (at for at in discovery_results if entry.unique_id == at.airtouch_id), None
+        )
+        if not airtouch:
+            # Couldn't find the AirTouch device.
+            # As a general rule this shouldn't happen because we are using discovery.
+            # However, it might happen if the AirTouch console is offline or the
+            # user configured with unicast discovery and the AirTouch console got a
+            # new IP address.
+            raise ConfigEntryNotReady("AirTouch not detected on network")
+    else:
+        # Direct connection mode: skip UDP discovery and connect to the
+        # configured console address over TCP. This supports network
+        # configurations where discovery responses cannot be received, e.g.
+        # when the console is on a different subnet/VLAN to Home Assistant.
+        if connection_mode == ConnectionMode.DIRECT_AT4:
+            model = pyairtouch.AirTouchModel.AIRTOUCH_4
+            port = DIRECT_PORT_AT4
+        else:
+            model = pyairtouch.AirTouchModel.AIRTOUCH_5
+            port = DIRECT_PORT_AT5
+
+        airtouch = pyairtouch.connect(
+            model,
+            entry.data[CONF_HOST],
+            port,
+            airtouch_id=entry.unique_id,
+            name=entry.title,
+        )
 
     if not await airtouch.init():
         await airtouch.shutdown()

--- a/custom_components/airtouch/config_flow.py
+++ b/custom_components/airtouch/config_flow.py
@@ -15,15 +15,19 @@ from homeassistant.core import callback
 from homeassistant.helpers import selector
 
 from .const import (
+    CONF_CONNECTION_MODE,
     CONF_MINOR_VERSION,
     CONF_SPILL_BYPASS,
     CONF_SPILL_ZONES,
     CONF_VERSION,
+    DIRECT_PORT_AT4,
+    DIRECT_PORT_AT5,
     DOMAIN,
     OPTIONS_ALLOW_ZONE_HVAC_MODE_CHANGES,
     OPTIONS_ALLOW_ZONE_HVAC_MODE_CHANGES_DEFAULT,
     OPTIONS_MIN_TARGET_TEMPERATURE_STEP,
     OPTIONS_MIN_TARGET_TEMPERATURE_STEP_DEFAULT,
+    ConnectionMode,
     SpillBypass,
 )
 
@@ -119,12 +123,80 @@ class AirTouchConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                             CONF_HOST,
                             default=self.context.get(CONF_HOST),
                         ): str,
+                        vol.Required(
+                            CONF_CONNECTION_MODE,
+                            default=self.context.get(
+                                CONF_CONNECTION_MODE, ConnectionMode.DISCOVERY.value
+                            ),
+                        ): selector.SelectSelector(
+                            selector.SelectSelectorConfig(
+                                options=[x.value for x in ConnectionMode],
+                                mode=selector.SelectSelectorMode.DROPDOWN,
+                                translation_key=CONF_CONNECTION_MODE,
+                            )
+                        ),
                     }
                 ),
                 errors=errors,
             )
 
+        connection_mode = ConnectionMode(
+            info.get(CONF_CONNECTION_MODE, ConnectionMode.DISCOVERY.value)
+        )
+        self.context[CONF_CONNECTION_MODE] = connection_mode.value  # type: ignore[literal-required]
+        if connection_mode != ConnectionMode.DISCOVERY:
+            return await self.async_step_direct_connect(
+                info[CONF_HOST], connection_mode
+            )
+
         return await self.async_step_discover_airtouch(info[CONF_HOST])
+
+    async def async_step_direct_connect(
+        self,
+        remote_host: str,
+        connection_mode: ConnectionMode,
+    ) -> "config_entries.ConfigFlowResult":
+        """Connect directly to a known AirTouch console, skipping UDP discovery.
+
+        UDP discovery doesn't work in some network configurations, e.g. when
+        the AirTouch console is on a different subnet/VLAN to Home Assistant
+        and discovery responses cannot be routed back. In this mode the user
+        tells us the model and we open a direct TCP connection to validate
+        the configuration.
+        """
+        self.context[CONF_HOST] = remote_host  # type: ignore[literal-required]
+
+        if connection_mode == ConnectionMode.DIRECT_AT4:
+            model = pyairtouch.AirTouchModel.AIRTOUCH_4
+            port = DIRECT_PORT_AT4
+        else:
+            model = pyairtouch.AirTouchModel.AIRTOUCH_5
+            port = DIRECT_PORT_AT5
+
+        airtouch = pyairtouch.connect(
+            model,
+            remote_host,
+            port,
+            airtouch_id=f"direct-{remote_host}",
+            name=f"{model.value} ({remote_host})",
+        )
+
+        connected = await airtouch.init()
+        if not connected or not airtouch.air_conditioners:
+            await airtouch.shutdown()
+            return await self.async_step_user_host(
+                errors={CONF_HOST: "no_devices_found"}
+            )
+        await airtouch.shutdown()
+
+        await self.async_set_unique_id(airtouch.airtouch_id)
+        self._abort_if_unique_id_configured()
+
+        self.context[_CONTEXT_TITLE] = airtouch.name  # type: ignore[literal-required]
+        self.context[_CONTEXT_AIRTOUCH_API] = airtouch  # type: ignore[literal-required]
+        self.context[_CONTEXT_REMAINING_AIRTOUCHES] = []  # type: ignore[literal-required]
+
+        return await self.async_step_settings()
 
     async def async_step_settings(
         self,
@@ -219,6 +291,9 @@ class AirTouchConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             title=self.context[_CONTEXT_TITLE],  # type: ignore[literal-required]
             data={
                 CONF_HOST: self.context[CONF_HOST],  # type: ignore[literal-required]
+                CONF_CONNECTION_MODE: self.context.get(
+                    CONF_CONNECTION_MODE, ConnectionMode.DISCOVERY.value
+                ),
                 CONF_SPILL_BYPASS: self.context[CONF_SPILL_BYPASS],  # type: ignore[literal-required]
                 CONF_SPILL_ZONES: self.context[CONF_SPILL_ZONES],  # type: ignore[literal-required]
             },

--- a/custom_components/airtouch/const.py
+++ b/custom_components/airtouch/const.py
@@ -18,6 +18,14 @@ CONF_SPILL_BYPASS = "spill_bypass"
 # Only valid if CONF_SPILL_BYPASS == SpillBypass.SPILL
 CONF_SPILL_ZONES = "spill_zones"
 
+# How the integration connects to the AirTouch console.
+# "discovery" (default) uses UDP discovery (broadcast or unicast).
+# The direct modes skip UDP discovery entirely and open a TCP connection to
+# the known console address. This supports networks where the console is on a
+# different subnet/VLAN to Home Assistant and UDP discovery responses cannot
+# be received.
+CONF_CONNECTION_MODE = "connection_mode"
+
 OPTIONS_MIN_TARGET_TEMPERATURE_STEP = "min_target_temperature_step"
 OPTIONS_MIN_TARGET_TEMPERATURE_STEP_DEFAULT = PRECISION_HALVES
 
@@ -31,3 +39,16 @@ class SpillBypass(enum.Enum):
 
     SPILL = "spill"
     BYPASS = "bypass"
+
+
+class ConnectionMode(enum.Enum):
+    """How to connect to the AirTouch console."""
+
+    DISCOVERY = "discovery"
+    DIRECT_AT4 = "direct_at4"
+    DIRECT_AT5 = "direct_at5"
+
+
+# Default TCP ports for direct connections.
+DIRECT_PORT_AT4 = 9004
+DIRECT_PORT_AT5 = 9005

--- a/custom_components/airtouch/translations/en.json
+++ b/custom_components/airtouch/translations/en.json
@@ -30,7 +30,11 @@
       },
       "user_host": {
         "data": {
-          "host": "Host"
+          "host": "Host",
+          "connection_mode": "Connection method"
+        },
+        "data_description": {
+          "connection_mode": "Use Discovery unless it fails. Direct connection skips UDP discovery and connects straight to the console over TCP — needed when the console is on a different subnet/VLAN to Home Assistant."
         },
         "description": "Enter the host name or IP Address of the AirTouch wall panel.",
         "title": "Set up the AirTouch connection details"
@@ -48,6 +52,13 @@
     }
   },
   "selector": {
+    "connection_mode": {
+      "options": {
+        "discovery": "Discovery (default)",
+        "direct_at4": "Direct connection — AirTouch 4",
+        "direct_at5": "Direct connection — AirTouch 5"
+      }
+    },
     "hvac_mode": {
       "options": {
         "cool": "Cool",


### PR DESCRIPTION
## Problem

When the AirTouch console is on a different subnet/VLAN to Home Assistant, setup fails with "Failed to connect to AirTouch console" even though the console is fully reachable over TCP. The console only answers UDP discovery via broadcast, which doesn't cross subnets — and because `async_setup_entry` re-runs discovery on every start, there's no way to use the integration in this topology at all, even with a manual host.

## Solution

Adds a **Connection method** selector to the manual host step of the config flow:

- **Discovery** (default) — existing behaviour, unchanged.
- **Direct — AirTouch 4** / **Direct — AirTouch 5** — skips UDP discovery entirely and connects via `pyairtouch.connect()` with the known host and the standard port for the selected model. The connection is validated with `init()` during the flow, and `async_setup_entry` uses the same direct path on startup (`connection_mode` is stored in the config entry).

Entries created via discovery are completely unaffected; `connection_mode` defaults to `discovery` for existing config entries.

## Testing

Running for some time on real AirTouch 4 hardware (console 1.4.4 / main module 1.1.0.0) with Home Assistant on a different VLAN to the console (TCP 9004 routed, UDP broadcast not crossing). Setup, entity creation, zone control, and restarts all work via the direct path. Discovery path re-tested on the same network for no regression (fails to find the console, as expected cross-VLAN, and succeeds when HA and console share a subnet).

English translations included for the new selector.
